### PR TITLE
Fix claim_code decryption and field ordering in full report CSV

### DIFF
--- a/src/components/pages/campaign/index.tsx
+++ b/src/components/pages/campaign/index.tsx
@@ -123,11 +123,13 @@ const mapDispatcherToProps = (dispatch: IAppDispatch) => {
     },
 
     downloadReport: (
-      campaign_id: string
+      campaign_id: string,
+      encryptionKey?: string
     ) => {
       dispatch(
         downloadReport(
-          campaign_id
+          campaign_id,
+          encryptionKey
         )
       )
     },
@@ -882,7 +884,7 @@ const Campaign: FC<ReduxType & IProps & RouteComponentProps> = ({
 
         {sponsored && <AsideButtonsContainer>
           <AsideButton
-            onClick={() => downloadReport(campaign_id)}
+            onClick={() => downloadReport(campaign_id, sdk ? encryptionKey : undefined)}
           >
             <Icons.DownloadReportIcon />
             Download full report

--- a/src/data/store/reducers/campaigns/async-actions/download-report.tsx
+++ b/src/data/store/reducers/campaigns/async-actions/download-report.tsx
@@ -5,15 +5,19 @@ import { RootState } from 'data/store'
 import { CampaignsActions } from '../types'
 import { campaignsApi } from 'data/api'
 import * as actionsCampaigns from '../actions'
+import * as actionsUser from '../../user/actions'
+import * as actionsAsyncUser from '../../user/async-actions'
 import {
   downloadLinksAsCSV,
   alertError,
   defineNetworkName
 } from 'helpers'
 import { plausibleApi } from 'data/api'
+import { decrypt } from 'lib/crypto'
 
 const downloadReport = (
-  campaignId: string
+  campaignId: string,
+  encryptionKey?: string
 ) => {
   return async (
     dispatch: Dispatch<CampaignActions | UserActions | CampaignsActions>,
@@ -21,27 +25,62 @@ const downloadReport = (
   ) => {
     const { user: { chainId } } = getState()
     if (!campaignId) { return alertError ('campaignId is not provided') }
-    try {
-    
-      const { data: { links_data } } = await campaignsApi.getReport(campaignId)
-      if (links_data.length === 0) {
-        alertError('No data for report. At least one claimed link is needed for report')
-        return dispatch(actionsCampaigns.setLoading(false))
-      }
-      downloadLinksAsCSV(links_data, `REPORT-${campaignId}`)
-      plausibleApi.invokeEvent({
-        eventName: 'download_report',
-        data: {
-          network: defineNetworkName(chainId),
-          type: 'campaign',
-          campaignId
+
+    const callback = async (key: string) => {
+      dispatch(actionsCampaigns.setLoading(true))
+
+      try {
+        const { data: { links_data } } = await campaignsApi.getReport(campaignId)
+        if (links_data.length === 0) {
+          alertError('No data for report. At least one claimed link is needed for report')
+          return dispatch(actionsCampaigns.setLoading(false))
         }
-      })
+
+        const decryptedLinksData = links_data.map((link: any) => {
+          const { encrypted_claim_code, encrypted_claim_link, link_id, ...rest } = link
+          let claim_code: string | null = null
+          if (encrypted_claim_code) {
+            try {
+              claim_code = decrypt(encrypted_claim_code, encryptionKey || key)
+            } catch (err) {
+              console.error('Failed to decrypt claim code for link', err)
+            }
+          }
+          return { link_id, claim_code, ...rest }
+        })
+
+        downloadLinksAsCSV(decryptedLinksData, `REPORT-${campaignId}`)
+        plausibleApi.invokeEvent({
+          eventName: 'download_report',
+          data: {
+            network: defineNetworkName(chainId),
+            type: 'campaign',
+            campaignId
+          }
+        })
+      } catch (err) {
+        alertError('Check console for more info')
+        console.error('Some error occured', err)
+      }
       dispatch(actionsCampaigns.setLoading(false))
-    } catch (err) {
-      alertError('Check console for more info')
-      console.error('Some error occured', err)
     }
+
+    let dashboardKey = actionsAsyncUser.useDashboardKey(
+      getState
+    )
+
+    if (!dashboardKey) {
+      if (!encryptionKey) {
+        dispatch(actionsCampaigns.setLoading(false))
+        dispatch(actionsUser.setDashboardKeyPopup(true))
+        dispatch(actionsUser.setDashboardKeyPopupCallback(callback))
+        return
+      } else {
+        dashboardKey = encryptionKey
+      }
+    }
+
+    callback(dashboardKey)
   }
 }
 

--- a/src/types/link-decrypted.tsx
+++ b/src/types/link-decrypted.tsx
@@ -1,6 +1,7 @@
 type TLinkDecrypted = {
   link_id: string
   claim_link: string
+  claim_code: string | null
   token_address?: string | null
   token_amount?: string | null
   token_id?: string | null

--- a/src/types/link-decrypted.tsx
+++ b/src/types/link-decrypted.tsx
@@ -1,7 +1,7 @@
 type TLinkDecrypted = {
   link_id: string
   claim_link: string
-  claim_code: string | null
+  claim_code?: string | null
   token_address?: string | null
   token_amount?: string | null
   token_id?: string | null


### PR DESCRIPTION
## Summary
- **Fix decryption**: Use raw `dashboardKey` (not derived `encryptionKey`) for non-SDK campaigns, matching the key used during link encryption. SDK campaigns still use the derived key when available.
- **Remove `encrypted_claim_link`**: Strip encrypted fields from the CSV output so only decrypted/useful data is exported.
- **Reorder columns**: Put `link_id` first and `claim_code` second in the report CSV for readability.

## Test plan
- [ ] Download full report for a **non-SDK** sponsored campaign — verify `claim_code` column has decrypted values (no console errors)
- [ ] Download full report for an **SDK** campaign — verify decryption still works
- [ ] Verify `encrypted_claim_link` column no longer appears in the CSV
- [ ] Verify column order: `link_id`, `claim_code`, then remaining fields
- [ ] Verify batch CSV download still works for the same campaigns

🤖 Generated with [Claude Code](https://claude.com/claude-code)